### PR TITLE
[FEAT] 챌린지 생성하기 기능 구현. 멤버 임시 지정, 사진 기능X

### DIFF
--- a/src/main/java/com/tikklesaver/domain/Category/repository/CategoryRepository.java
+++ b/src/main/java/com/tikklesaver/domain/Category/repository/CategoryRepository.java
@@ -1,4 +1,7 @@
 package com.tikklesaver.domain.Category.repository;
 
-public interface CategoryRepository {
+import com.tikklesaver.domain.Category.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
 }

--- a/src/main/java/com/tikklesaver/domain/Challenge/controller/ChallengeController.java
+++ b/src/main/java/com/tikklesaver/domain/Challenge/controller/ChallengeController.java
@@ -1,0 +1,33 @@
+package com.tikklesaver.domain.Challenge.controller;
+
+import com.tikklesaver.domain.Challenge.converter.ChallengeConverter;
+import com.tikklesaver.domain.Challenge.dto.ChallengeRequestDTO;
+import com.tikklesaver.domain.Challenge.dto.ChallengeResponseDTO;
+import com.tikklesaver.domain.Challenge.entity.Challenge;
+import com.tikklesaver.domain.Challenge.service.ChallengeQueryService;
+import com.tikklesaver.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/challenge")
+public class ChallengeController {
+
+    private final ChallengeQueryService challengeQueryService;
+
+    @PostMapping
+    @Operation(summary = "챌린지 생성 API")
+    public ApiResponse<ChallengeResponseDTO.challengeResultDTO> createChallenge(
+            @RequestBody @Valid ChallengeRequestDTO.CreateChallengeDTO request) {
+
+        //임시 memberId
+        Long memberId = 1L;
+        Challenge challenge = challengeQueryService.createChallenge(memberId, request);
+        return ApiResponse.onSuccess(ChallengeConverter.toChallengeResultDTO(challenge));
+    }
+}

--- a/src/main/java/com/tikklesaver/domain/Challenge/converter/ChallengeConverter.java
+++ b/src/main/java/com/tikklesaver/domain/Challenge/converter/ChallengeConverter.java
@@ -1,0 +1,34 @@
+package com.tikklesaver.domain.Challenge.converter;
+
+import com.tikklesaver.domain.Category.entity.Category;
+import com.tikklesaver.domain.Challenge.dto.ChallengeRequestDTO;
+import com.tikklesaver.domain.Challenge.dto.ChallengeResponseDTO;
+import com.tikklesaver.domain.Challenge.entity.Challenge;
+import com.tikklesaver.domain.member.entity.Member;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+public class ChallengeConverter {
+
+    public static Challenge toChallenge(Member member, ChallengeRequestDTO.CreateChallengeDTO request, Category category, String imageUrl) {
+        return Challenge.builder()
+                .title(request.getTitle())
+                .description(request.getDescription())
+                .challengeUrl(imageUrl)
+                .missionMethods(request.getMissionMethods())
+                .category(category)
+                .publicStatus(request.getPublicStatus())
+                .member(member)
+                .build();
+    }
+
+    public static ChallengeResponseDTO.challengeResultDTO toChallengeResultDTO(Challenge challenge) {
+        return ChallengeResponseDTO.challengeResultDTO.builder()
+                .challengeId(challenge.getId())
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+}

--- a/src/main/java/com/tikklesaver/domain/Challenge/dto/ChallengeRequestDTO.java
+++ b/src/main/java/com/tikklesaver/domain/Challenge/dto/ChallengeRequestDTO.java
@@ -1,0 +1,34 @@
+package com.tikklesaver.domain.Challenge.dto;
+
+import com.tikklesaver.domain.Category.entity.Category;
+import com.tikklesaver.domain.Challenge.entity.enums.PublicStatus;
+import jakarta.persistence.Column;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.util.List;
+
+public class ChallengeRequestDTO {
+
+    @Getter
+    public static class CreateChallengeDTO {
+
+        @NotEmpty
+        @Column(nullable = false, length = 100)
+        String title;
+        @NotEmpty
+        @Column(nullable = false, length = 4000)
+        String description;
+        @NotNull
+        Long categoryId;
+        @NotNull
+        PublicStatus publicStatus;
+        @NotNull
+        List<String> missionMethods;
+
+
+
+    }
+
+}

--- a/src/main/java/com/tikklesaver/domain/Challenge/dto/ChallengeResponseDTO.java
+++ b/src/main/java/com/tikklesaver/domain/Challenge/dto/ChallengeResponseDTO.java
@@ -1,0 +1,20 @@
+package com.tikklesaver.domain.Challenge.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class ChallengeResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class challengeResultDTO {
+        Long challengeId;
+        LocalDateTime createdAt;
+    }
+}

--- a/src/main/java/com/tikklesaver/domain/Challenge/entity/Challenge.java
+++ b/src/main/java/com/tikklesaver/domain/Challenge/entity/Challenge.java
@@ -1,12 +1,18 @@
 package com.tikklesaver.domain.Challenge.entity;
 
+import com.tikklesaver.domain.Category.entity.Category;
 import com.tikklesaver.domain.Challenge.entity.enums.PublicStatus;
+import com.tikklesaver.domain.member.entity.Member;
 import com.tikklesaver.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Builder
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Entity
@@ -29,14 +35,23 @@ public class Challenge extends BaseEntity {
     private PublicStatus publicStatus;
     
     // 인증 방식
-
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "challenge_mission_methods", joinColumns = @JoinColumn(name = "challenge_id"))
+    @Column(name = "mission_method")
+    private List<String> missionMethods = new ArrayList<>();
     
     // 챌린지 이미지
     @Column(nullable = false)
     private String challengeUrl;
 
     // 챌린지장 ID (FK)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "leader_id")
+    private Member member;
 
     // 카테고리 ID (FK)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
 
 }

--- a/src/main/java/com/tikklesaver/domain/Challenge/repository/ChallengeRepository.java
+++ b/src/main/java/com/tikklesaver/domain/Challenge/repository/ChallengeRepository.java
@@ -1,0 +1,7 @@
+package com.tikklesaver.domain.Challenge.repository;
+
+import com.tikklesaver.domain.Challenge.entity.Challenge;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
+}

--- a/src/main/java/com/tikklesaver/domain/Challenge/service/ChallengeQueryService.java
+++ b/src/main/java/com/tikklesaver/domain/Challenge/service/ChallengeQueryService.java
@@ -1,0 +1,9 @@
+package com.tikklesaver.domain.Challenge.service;
+
+import com.tikklesaver.domain.Challenge.dto.ChallengeRequestDTO;
+import com.tikklesaver.domain.Challenge.entity.Challenge;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ChallengeQueryService {
+    Challenge createChallenge(Long memberId, ChallengeRequestDTO.CreateChallengeDTO request);
+}

--- a/src/main/java/com/tikklesaver/domain/Challenge/service/ChallengeQueryServiceImpl.java
+++ b/src/main/java/com/tikklesaver/domain/Challenge/service/ChallengeQueryServiceImpl.java
@@ -1,0 +1,47 @@
+package com.tikklesaver.domain.Challenge.service;
+
+import com.tikklesaver.domain.Category.entity.Category;
+import com.tikklesaver.domain.Category.repository.CategoryRepository;
+import com.tikklesaver.domain.Challenge.converter.ChallengeConverter;
+import com.tikklesaver.domain.Challenge.dto.ChallengeRequestDTO;
+import com.tikklesaver.domain.Challenge.entity.Challenge;
+import com.tikklesaver.domain.Challenge.repository.ChallengeRepository;
+import com.tikklesaver.domain.member.entity.Member;
+import com.tikklesaver.domain.member.repository.MemberRepository;
+import com.tikklesaver.global.apiPayload.code.status.ErrorStatus;
+import com.tikklesaver.global.apiPayload.exception.handler.ChallengeHandler;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.apache.ibatis.javassist.NotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class ChallengeQueryServiceImpl implements ChallengeQueryService {
+
+    private final MemberRepository memberRepository;
+    private final ChallengeRepository challengeRepository;
+    private final CategoryRepository categoryRepository;
+    @Override
+    public Challenge createChallenge(Long memberId, ChallengeRequestDTO.CreateChallengeDTO request) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("해당하는 유저를 찾을 수 없습니다. ID: " + memberId));
+
+        Category category = categoryRepository.findById(request.getCategoryId())
+                .orElseThrow(() -> new EntityNotFoundException("Category not found ID: " + request.getCategoryId()));
+
+        String imageUrl = "String";
+
+        if (request.getTitle() == null || request.getTitle().isEmpty()) {
+            throw new ChallengeHandler(ErrorStatus.TITLE_NOT_PROVIDED);
+        }
+        if (request.getDescription() == null || request.getDescription().isEmpty()) {
+            throw new ChallengeHandler(ErrorStatus.DESCRIPTION_NOT_PROVIDED);
+        }
+
+        Challenge newChallenge = ChallengeConverter.toChallenge(member, request,category,imageUrl);
+        return challengeRepository.save(newChallenge);
+    }
+}

--- a/src/main/java/com/tikklesaver/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/tikklesaver/domain/member/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.tikklesaver.domain.member.repository;
+
+import com.tikklesaver.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/tikklesaver/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/tikklesaver/global/apiPayload/code/status/ErrorStatus.java
@@ -16,9 +16,13 @@ public enum ErrorStatus implements BaseErrorCode {
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
-
     // 테스트
-    TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "이거는 테스트");
+    TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "이거는 테스트"),
+
+    //챌린지
+    TITLE_NOT_PROVIDED(HttpStatus.BAD_REQUEST, "POST4001", "제목은 필수 입력 사항입니다."),
+    DESCRIPTION_NOT_PROVIDED(HttpStatus.BAD_REQUEST, "POST4002", "소개는 필수 입력 사항입니다.");
+
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/tikklesaver/global/apiPayload/exception/handler/ChallengeHandler.java
+++ b/src/main/java/com/tikklesaver/global/apiPayload/exception/handler/ChallengeHandler.java
@@ -1,0 +1,13 @@
+package com.tikklesaver.global.apiPayload.exception.handler;
+
+import com.tikklesaver.global.apiPayload.code.BaseErrorCode;
+import com.tikklesaver.global.apiPayload.exception.GeneralException;
+
+public class ChallengeHandler extends GeneralException {
+    public ChallengeHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+
+
+
+}


### PR DESCRIPTION
### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #1 

## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 챌린지 생성하기 기능을 구현했습니다
- member 1을 임시로 추가해두었고 카테고리도 디비에 넣어두었습니다. challenge 기능 구현을 위해 memberRepository, categoryRepository를 생성했습니다. 
- member와 이미지는 우선 하드 코딩으로 구현하였습니다.

## 📌 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 리뷰를 원하는 부분 등을 적어주세요! -->
- ExpenseComment 테이블 설정에 오류가 있습니다. 확인 부탁합니다
- service에서 set하는게 안좋다고 들어서 converter에 매개변수로 member을 추가했는데 이렇게 하는게 나을까요?
