### PR TITLE
[fix #116] Cors 오류 해결

### DIFF
--- a/src/main/java/com/tikklesaver/global/config/CorsConfig.java
+++ b/src/main/java/com/tikklesaver/global/config/CorsConfig.java
@@ -2,25 +2,26 @@ package com.tikklesaver.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.Arrays;
 
 @Configuration
 public class CorsConfig {
     @Bean
-    public WebMvcConfigurer corsConfigurer() {
-        return new WebMvcConfigurer() {
-            @Override
-            public void addCorsMappings(CorsRegistry registry) {
-                registry.addMapping("/**")
-                        .allowedOrigins(
-                                "http://localhost:8080",
-                                "http://localhost:3000"
-                        )
-                        .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
-                        .allowedHeaders("*")
-                        .allowCredentials(true);
-            }
-        };
+    public static CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000", "http://localhost:8080"));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(Arrays.asList("*"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }

--- a/src/main/java/com/tikklesaver/global/config/SecurityConfig.java
+++ b/src/main/java/com/tikklesaver/global/config/SecurityConfig.java
@@ -38,6 +38,9 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http, MemberRepository memberRepository) throws Exception {
         http
+                // CORS 설정
+                .cors(cors -> cors
+                        .configurationSource(CorsConfig.corsConfigurationSource()))
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests((requests) -> requests
                         // Swagger UI 관련 경로에 접근 허용
@@ -46,6 +49,7 @@ public class SecurityConfig {
 //                        .requestMatchers("/").permitAll()
 //                        .requestMatchers("/**").permitAll()
 //                        .requestMatchers("/api/**").permitAll()
+
                         .requestMatchers("/api/check-id/**").permitAll()
                         .requestMatchers("api/users/onboarding/**").permitAll()
                                 .requestMatchers(AUTH_WHITELIST).permitAll()

--- a/src/main/java/com/tikklesaver/global/config/WebConfig.java
+++ b/src/main/java/com/tikklesaver/global/config/WebConfig.java
@@ -22,12 +22,13 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:3000")
+                .allowedOrigins("http://localhost:3000", "http://localhost:8080")
                 .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true)
                 .maxAge(3600);
     }
+
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {


### PR DESCRIPTION
### ✅ Issue
Resolved #116 

- 어떤 버그?
Cors 오류

- 어떤 상황?
local:3000에서 jwt accessToken을 헤더에 담아 요청 시 발생함.

- 문제?
Authorization 헤더가 없을 땐 서버가 특별한 처리를 안 해도 그냥 호출됨
Authorization 헤더가 있으면 → 브라우저는 먼저 OPTIONS 요청을 보냄 → 403 Forbidden 또는 CORS 에러 발생
→ WebMvcConfigurer로 CorsRegistry만 설정한 건 Spring MVC 레벨에서만 CORS를 허용하는 것이고, Spring Security가 있다면 따로 CORS 허용을 해줘야 함

## ⛏ 작업 내용
- CorsConfig에 CorsConfigurationSource 추가
- Spring Security CORS 허용
