### PR TITLE
Fix/jwt/#125

### DIFF
--- a/src/main/java/com/tikklesaver/domain/member/controller/MemberController.java
+++ b/src/main/java/com/tikklesaver/domain/member/controller/MemberController.java
@@ -60,11 +60,11 @@ public class MemberController {
     }
 
     @PostMapping("/refresh-token")
-    public ApiResponse<JwtDto> refresh(@RequestHeader("Authorization") String accessToken, @RequestHeader("Authorization-refresh") String refreshToken) throws Exception {
-        String jwtToken = accessToken.substring(7); // "Bearer " 제거
-        log.info("AccessToken: {}", jwtToken);
+    public ApiResponse<JwtDto> refresh(@RequestHeader("Authorization") String refreshToken, @CurrentMember Member member) throws Exception {
+        String jwtToken = refreshToken.substring(7); // "Bearer " 제거
+        log.info("refreshToken: {}", jwtToken);
 
-        return ApiResponse.onSuccess(memberCommandService.refreshAccessToken(accessToken, refreshToken));
+        return ApiResponse.onSuccess(memberCommandService.refreshAccessToken(member, refreshToken));
     }
 
     @PostMapping("/logout")
@@ -73,6 +73,7 @@ public class MemberController {
         return ApiResponse.onSuccess("로그아웃에 성공하였습니다.");
     }
 
+    //아이디 중복 확인
     @PostMapping("/check-id/{id}")
     public ApiResponse<String> checkId(@PathVariable(name = "id") String id) throws Exception {
         memberCommandService.checkId(id);

--- a/src/main/java/com/tikklesaver/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/tikklesaver/domain/member/service/MemberCommandService.java
@@ -17,7 +17,7 @@ public interface MemberCommandService {
 
     JwtDto login(@Valid LoginRequestDto request);
 
-    JwtDto refreshAccessToken(String jwtToken, String refreshToken);
+    JwtDto refreshAccessToken(Member member, String refreshToken);
 
     void logout(Member member);
 

--- a/src/main/java/com/tikklesaver/domain/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/com/tikklesaver/domain/member/service/MemberCommandServiceImpl.java
@@ -53,12 +53,6 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     private final UuidRepository uuidRepository;
     private final ChallengeScrapRepository challengeScrapRepository;
 
-    @Value("${jwt.access.header}")
-    private String accessHeader;
-
-    @Value("${jwt.refresh.header}")
-    private String refreshHeader;
-
 
 
     @Override
@@ -114,19 +108,13 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
 
     @Override
-    public JwtDto refreshAccessToken(String accessToken, String refreshToken) throws JwtHandler {
-        accessToken = accessToken.substring(7);
+    public JwtDto refreshAccessToken(Member member, String refreshToken) throws JwtHandler {
         refreshToken = refreshToken.substring(7);
-
-        //refreshToken 유효성 검증 / accessToken은 이미 만료가 지나도 상관 없는 상태
+        String accessToken;
+        //refreshToken 유효성 검증
         if (!jwtUtil.isValidToken(refreshToken)) {
             throw new JwtHandler(ErrorStatus.INVALID_TOKEN);
         }else{
-            //accessToken에서 loginId 추출 -> db에 refreshToken 조회
-            String loginId = jwtUtil.getUserId(accessToken);
-            Optional<Member> optionalMember = memberRepository.findByLoginId(loginId);
-            Member member = optionalMember.get();
-
             String dbToken = member.getRefreshToken();
 
             if(dbToken.equals(refreshToken)){

--- a/src/main/java/com/tikklesaver/global/jwt/filter/JwtAuthFilter.java
+++ b/src/main/java/com/tikklesaver/global/jwt/filter/JwtAuthFilter.java
@@ -40,7 +40,11 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             String token = authorizationHeader.substring(7);
             //JWT 유효성 검증
             if (!jwtUtil.isValidToken(token)) {
-//                throw new JwtHandler(ErrorStatus.INVALID_TOKEN);//filter에서는 예외 따로 잡아줘야 함.
+                SecurityContextHolder.clearContext(); // 인증 정보 명시적으로 제거
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401 상태 코드
+                response.setContentType("application/json;charset=UTF-8"); // JSON 응답 설정
+                response.getWriter().write("{\"message\": \"유효하지 않은 토큰입니다.\"}"); // 에러 메시지 바디
+                return; // 요청 종료 (다음 필터로 넘기지 않음)
             } else{
                 String loginId = jwtUtil.getUserId(token);
 


### PR DESCRIPTION
### ✅ Issue
Resolved #125

## ⛏ 작업 내용
- jwt를 헤더에 담아서 보낼 때 유효성 검증 실패 시 filter 에서 더 나아가지 않고 바로 401 응답처리.
- accessToken 재발급 시 refreshToken만 Authorization 헤더 필드에 담아 요청. 